### PR TITLE
Changed match_taxa

### DIFF
--- a/db/schema/taxa_functions.sql
+++ b/db/schema/taxa_functions.sql
@@ -17,12 +17,15 @@ AS $BODY$
           AND match_type <> 'complex'
       WHERE mref.scientific_name ILIKE $1
   ), children_taxa_obs AS (
-      SELECT DISTINCT mlu.id_taxa_obs
+      SELECT DISTINCT mpref.id_taxa_obs
       FROM rubus.taxa_obs_ref_preferred mpref
-      JOIN rubus.taxa_obs_ref_lookup mlu
-          ON mpref.id_taxa_ref = mlu.id_taxa_ref
-          AND is_parent IS true
       WHERE mpref.scientific_name ILIKE $1
+      AND EXISTS (
+          SELECT 1
+          FROM rubus.taxa_obs_ref_lookup mlu
+          WHERE mlu.id_taxa_ref = mpref.id_taxa_ref
+            AND mlu.is_parent IS TRUE
+      )
   ), pref_synonyms AS (
       SELECT DISTINCT syn_pref.id_taxa_obs
       FROM (

--- a/db/schema/taxa_functions.sql
+++ b/db/schema/taxa_functions.sql
@@ -7,41 +7,9 @@ CREATE OR REPLACE FUNCTION rubus.match_taxa(
     LANGUAGE 'sql'
     STABLE PARALLEL SAFE
 AS $BODY$
-  WITH matched_taxa_obs AS (
-      SELECT DISTINCT id_taxa_obs
-      FROM rubus.taxa_ref mref
-      JOIN rubus.taxa_obs_ref_lookup mlu
-          ON mref.id = mlu.id_taxa_ref
-          AND is_parent IS false
-          AND match_type IS NOT NULL
-          AND match_type <> 'complex'
-      WHERE mref.scientific_name ILIKE $1
-  ), children_taxa_obs AS (
-      SELECT DISTINCT mpref.id_taxa_obs
-      FROM rubus.taxa_obs_ref_preferred mpref
-      WHERE mpref.scientific_name ILIKE $1
-      AND EXISTS (
-          SELECT 1
-          FROM rubus.taxa_obs_ref_lookup mlu
-          WHERE mlu.id_taxa_ref = mpref.id_taxa_ref
-            AND mlu.is_parent IS TRUE
-      )
-  ), pref_synonyms AS (
-      SELECT DISTINCT syn_pref.id_taxa_obs
-      FROM (
-           SELECT id_taxa_obs FROM matched_taxa_obs
-             UNION
-            SELECT id_taxa_obs FROM children_taxa_obs
-            ) AS all_obs
-      JOIN rubus.taxa_obs_ref_preferred mpref
-          ON all_obs.id_taxa_obs = mpref.id_taxa_obs
-          AND mpref.is_match
-      JOIN rubus.taxa_obs_ref_preferred syn_pref
-          ON mpref.id_taxa_ref = syn_pref.id_taxa_ref
-          AND syn_pref.is_match IS true
-  )
-  SELECT id_taxa_obs
-  FROM pref_synonyms
+  SELECT DISTINCT id_taxa_obs
+  FROM rubus.taxa_obs_ref_preferred
+  WHERE scientific_name ILIKE $1;
 $BODY$;
 
 ALTER FUNCTION rubus.match_taxa(text)

--- a/db/tests/test_match_taxa.py
+++ b/db/tests/test_match_taxa.py
@@ -24,26 +24,18 @@ class TestMatchTaxa(unittest.TestCase):
     def test_match_taxa_all_canis(self, taxa_name='Canis'):
         query = self.QUERY_MATCH_TAXA
         df = pd.read_sql(query, self.conn, params = (taxa_name,))
-        allowed = {'Canis', 'Canis lupus', 'Canis latrans'}        
+        allowed = {'Canis', 'Canis lupus', 'Canis latrans', 'Canis lycaon'}        
         self.assertTrue(set(df['valid_scientific_name'].unique()).issubset(allowed))
         
-        
-    def test_match_taxa_Picoides_villosus_Dendrocopos_villosus(self):
-        query = self.QUERY_MATCH_TAXA
-        df_picoides = pd.read_sql(query, self.conn, params = ('Picoides villosus',))
-        self.assertTrue('Dryobates villosus' in df_picoides['observed_scientific_name'].values)
-        self.assertTrue('Leuconotopicus villosus' in df_picoides['observed_scientific_name'].values)
-        self.assertTrue(df_picoides['valid_scientific_name'].unique() == 'Dryobates villosus')
-        
-        df_dendrocopos = pd.read_sql(query, self.conn, params = ('Dendrocopos villosus',))
-        self.assertTrue('Dryobates villosus' in df_dendrocopos['observed_scientific_name'].values)
-        self.assertTrue('Leuconotopicus villosus' in df_dendrocopos['observed_scientific_name'].values)
-        self.assertTrue(df_dendrocopos['valid_scientific_name'].unique() == 'Dryobates villosus')
-
-    def test_match_taxa_Picoides_villosus_villosus_no_subsp(self, taxa_name='Picoides villosus villosus'):
+    def test_dryobates_villosus_all_synonyms(self, taxa_name='Dryobates villosus'):
         query = self.QUERY_MATCH_TAXA
         df = pd.read_sql(query, self.conn, params = (taxa_name,))
-        self.assertTrue('subspecies' not in df['rank'].values)
+        required = {'Dryobates villosus', 'Picoides villosus', 'Picoides villosus villosus',
+                   'Picoides villosus septentrionalis', 'Dendrocopos villosus',
+                   'Dendrocopos villosus villosus', 'Leuconotopicus villosus',
+                   'Leuconotopicus villosus septentrionalis', 'Leuconotopicus villosus villosus',
+                   'dryobates villosus'}
+        self.assertTrue(set(df['observed_scientific_name'].unique()).issubset(required))
 
     def test_poa_nemoralis_only(self, taxa_name='Poa nemoralis'):
         query = self.QUERY_MATCH_TAXA
@@ -54,3 +46,13 @@ class TestMatchTaxa(unittest.TestCase):
         query = self.QUERY_MATCH_TAXA
         df_rhamnus = pd.read_sql(query, self.conn, params = (taxa_name,))
         self.assertTrue(df_rhamnus['valid_scientific_name'].str.contains('Rhamnus').all())
+
+#    Deprecated test: We no longer match synonyms as only valid scientific names are thrown in match_taxa, 
+#    so this test is no longer relevant.
+#    def test_match_taxa_Picoides_villosus_Dendrocopos_villosus(self):
+#       pass
+
+#   Deprecated test: We no longer match synonyms as only valid scientific names are thrown in match_taxa, 
+#   so this test is no longer relevant.
+#    def test_match_taxa_Picoides_villosus_villosus_no_subsp(self, taxa_name='Picoides villosus villosus'):
+#        pass


### PR DESCRIPTION
Est-ce qu'il y avait une raison pourquoi on prenait les DISTINCT id_taxa_obs de rubus.taxa_obs_ref_lookup et pas de rubus.taxa_obs_ref_preferred?

Si on prend par exemple 'Insecta', l'ancienne CTE children_taxa_obs renvoyait 53 id_taxa_obs de plus, alors que ma suggestion ici renvoit 53 id_taxa_obs de moins... pas sur de comprendre pourquoi.
Je pensais que c'était parce que c'était des id_taxa_obs qui n'avait pas passés le pipeline taxonomique, mais 16 de ces 53 id_taxa_obs se retrouvent bel et bien dans rubus.taxa_obs_ref_preferred, alors pas certain de comprendre pourquoi ça se rend pas.

Ceci étant dit, si la logique convient, ça roule maintenant en 1 seconde au lieu de 1min30.

On peut peut-être en parler en personne pour voir